### PR TITLE
Adicionado busca de guias por data

### DIFF
--- a/src/main/java/com/sistemadecadastro/cadastrodeguias/controller/GuiaController.java
+++ b/src/main/java/com/sistemadecadastro/cadastrodeguias/controller/GuiaController.java
@@ -88,4 +88,16 @@ public class GuiaController {
             return ResponseEntity.notFound().build();
         }
     }
+    @GetMapping("/search/date")
+    public ResponseEntity<List<Guia>> searchGuiasBetweenDates(
+            @RequestParam() LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate
+    ){
+        try{
+            var guias = guiaService.searchGuiasBetweenDates(startDate, endDate);
+            return ResponseEntity.ok(guias);
+        }catch(EmptyResultDataAccessException em){
+            return ResponseEntity.notFound().build();
+        }
+    }
 }

--- a/src/main/java/com/sistemadecadastro/cadastrodeguias/repository/GuiaRespository.java
+++ b/src/main/java/com/sistemadecadastro/cadastrodeguias/repository/GuiaRespository.java
@@ -22,4 +22,5 @@ public interface GuiaRespository extends JpaRepository<Guia, Integer> {
     public List<Guia> findGuiasByProcedimentoContainingIgnoreCase(@Size(min = 2) String procedimento);
     public List<Guia> findGuiasByDataNascimentoBefore(LocalDate dataNascimento);
     public List<Guia> findGuiasByNomeIgnoreCase(@Size(min = 3) String nome);
+    public List<Guia> findGuiasByDataRecebimentoBetween(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/sistemadecadastro/cadastrodeguias/service/GuiaService.java
+++ b/src/main/java/com/sistemadecadastro/cadastrodeguias/service/GuiaService.java
@@ -8,6 +8,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -76,6 +77,13 @@ public class GuiaService {
         var dataLimite = dataAtual.minusYears(60);
         var guias = guiaRespository.findGuiasByDataNascimentoBefore(dataLimite);
         if(guias.isEmpty()) throw new EmptyResultDataAccessException("Nenhuma guia de idoso encontrada", 1);
+        return guias;
+    }
+
+    public List<Guia> searchGuiasBetweenDates(LocalDate startDate, LocalDate end){
+        var endDate = end != null ? end : startDate;
+        var guias = guiaRespository.findGuiasByDataRecebimentoBetween(startDate, endDate);
+        if(guias.isEmpty()) throw new EmptyResultDataAccessException("Nenhuma guia encontrada nessas datas ", 1);
         return guias;
     }
 }


### PR DESCRIPTION
Foram adicionados metodos para busca de guias entre datas
- A busca vai buscar todas as guias entre uma data inicio e uma data final
- A data inicial é obrigatório mas a data final é opcional caso não seja passada nos argumentos da URL só será buscado guias da data inicial

Issue #10